### PR TITLE
Modal scrolling

### DIFF
--- a/dev/pages/Modal/Modal.vue
+++ b/dev/pages/Modal/Modal.vue
@@ -2,10 +2,10 @@
 	<div>
 		<button @click="show = true">Show me!</button>
 		<div style="height: 1000px; background-color: antiquewhite;"><p>This div is to simulate scroll behaviour (for freezing background purpose)</p></div>
-		<Modal :show="show" @close="show = false" width="400">
+		<Modal :show="show" @close="show = false" width="800">
 				<div style="padding: 20px;">
 				<h1>Hello, I'm a Modal!</h1>
-				<p>By default I freeze your background.<br> 
+				<p style="height: 2000px">By default I freeze your background.<br> 
 				Click and scroll around to test my behaviour.<br> 
 				If you have ideas to prettify me, please tell Giupetto..</p>
 				</div>

--- a/dev/pages/Modal/Modal.vue
+++ b/dev/pages/Modal/Modal.vue
@@ -3,11 +3,16 @@
 		<button @click="show = true">Show me!</button>
 		<div style="height: 1000px; background-color: antiquewhite;"><p>This div is to simulate scroll behaviour (for freezing background purpose)</p></div>
 		<Modal :show="show" @close="show = false" width="800">
-				<div style="padding: 20px;">
-				<h1>Hello, I'm a Modal!</h1>
-				<p style="height: 2000px">By default I freeze your background.<br> 
-				Click and scroll around to test my behaviour.<br> 
-				If you have ideas to prettify me, please tell Giupetto..</p>
+				<div slot="header">This is the header here</div>
+				<div>
+					<h1>Hello, I'm a Modal!</h1>
+					<p style="height: 2000px">By default I freeze your background.<br> 
+					Click and scroll around to test my behaviour.<br> 
+					If you have ideas to prettify me, please tell Giupetto..</p>
+				</div>
+				<div slot="footer">
+					<button @click="show = false">Close</button>
+					<button @click="show = false">Save</button>
 				</div>
 		</Modal>
 	</div>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -62,6 +62,9 @@ export default {
       }
     }
   },
+  mounted () {
+    freezeBackground()
+  },
   computed: {
     hasHeaderSlot () {
       return !!this.$slots['header']

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="modal">
+  <portal :to="targetPortal">
     <transition name="slide-fade">
       <div v-if="show" class="ovc-modal-backdrop">
         <div class="ovc-modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
@@ -43,6 +43,16 @@ export default {
       type: Boolean,
       default: true,
       required: false
+    },
+    allowBackgroundClose: {
+      type: Boolean,
+      default: true,
+      required: false
+    },
+    targetPortal: {
+      type: String,
+      default: 'modal',
+      required: false
     }
   },
   mixins: [ clickaway ],
@@ -64,7 +74,7 @@ export default {
   },
   mounted () {
     if (this.show) {
-    freezeBackground()
+      freezeBackground()
     }
   },
   computed: {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -3,10 +3,16 @@
     <transition name="slide-fade">
       <div v-if="show" class="modal-backdrop">
         <div class="modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
-          <div class="modal-subwrapper">
-            <div class="modal-content">
+          <div class="modal-content">
+            <div class="modal-header">
+              <slot name="header"></slot>
               <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
+            </div>
+            <div class="modal-body">
               <slot/>
+            </div>
+            <div class="modal-footer">
+              <slot name="footer"></slot>
             </div>
           </div>
         </div>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -11,7 +11,7 @@
             <div class="ovc-modal-body">
               <slot/>
             </div>
-            <div class="ovc-modal-footer"  v-if="hasFooterSlot">
+            <div class="ovc-modal-footer" v-if="hasFooterSlot">
               <slot name="footer"></slot>
             </div>
           </div>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -4,14 +4,14 @@
       <div v-if="show" class="modal-backdrop">
         <div class="modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
           <div class="modal-content">
-            <div class="modal-header">
+            <div class="modal-header" v-if="hasHeaderSlot">
               <slot name="header"></slot>
               <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
             </div>
             <div class="modal-body">
               <slot/>
             </div>
-            <div class="modal-footer">
+            <div class="modal-footer"  v-if="hasFooterSlot">
               <slot name="footer"></slot>
             </div>
           </div>
@@ -61,6 +61,14 @@ export default {
         unfreezeBackground()
       }
     }
+  },
+  computed: {
+    hasHeaderSlot () {
+      return !!this.$slots['header']
+    },
+    hasFooterSlot () {
+      return !!this.$slots['footer']
+    },
   },
   methods: {
     // for closing on escape

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -63,7 +63,9 @@ export default {
     }
   },
   mounted () {
+    if (this.show) {
     freezeBackground()
+    }
   },
   computed: {
     hasHeaderSlot () {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -6,9 +6,9 @@
           <div class="ovc-modal-content">
             <div class="ovc-modal-header" v-if="hasHeaderSlot">
               <slot name="header"></slot>
-              <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
             </div>
             <div class="ovc-modal-body">
+              <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
               <slot/>
             </div>
             <div class="ovc-modal-footer" v-if="hasFooterSlot">

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,17 +1,17 @@
 <template>
   <portal to="modal">
     <transition name="slide-fade">
-      <div v-if="show" class="modal-backdrop">
-        <div class="modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
-          <div class="modal-content">
-            <div class="modal-header" v-if="hasHeaderSlot">
+      <div v-if="show" class="ovc-modal-backdrop">
+        <div class="ovc-modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
+          <div class="ovc-modal-content">
+            <div class="ovc-modal-header" v-if="hasHeaderSlot">
               <slot name="header"></slot>
               <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
             </div>
-            <div class="modal-body">
+            <div class="ovc-modal-body">
               <slot/>
             </div>
-            <div class="modal-footer"  v-if="hasFooterSlot">
+            <div class="ovc-modal-footer"  v-if="hasFooterSlot">
               <slot name="footer"></slot>
             </div>
           </div>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -2,13 +2,13 @@
   <portal :to="targetPortal">
     <transition name="slide-fade">
       <div v-if="show" class="ovc-modal-backdrop">
-        <div class="ovc-modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="hideModal">
+        <div class="ovc-modal-wrapper" :style="{ width: `${width}px` }" v-on-clickaway="onBackgroundClick">
           <div class="ovc-modal-content">
             <div class="ovc-modal-header" v-if="hasHeaderSlot">
               <slot name="header"></slot>
             </div>
             <div class="ovc-modal-body">
-              <i class="mdi mdi-close" v-if="canClose" @click="hideModal"></i>
+              <i class="mdi mdi-close" v-if="canClose" @click="onCloseIconClick"></i>
               <slot/>
             </div>
             <div class="ovc-modal-footer" v-if="hasFooterSlot">
@@ -89,11 +89,25 @@ export default {
     // for closing on escape
     escapeHandler (e) {
       if (e.key === 'Escape' && this.show) {
-        this.hideModal()
+        this.onCloseIconClick() // simulate icon click
       }
     },
-    hideModal () {
-      if (this.canClose) this.$emit('close')
+    onCloseIconClick () {
+      if (!this.canClose) {
+        return
+      }
+      this.$emit('close')
+    },
+    onBackgroundClick(){
+      if(!this.canClose){
+        return
+      }
+      // If 'allowBackgroundClose' is false, the modal can only be closed by clicking the mdi-close icon.
+      // this check is used if e.g. you don't want people to accidentally close the modal by clicking next to it.
+      if (!this.allowBackgroundClose) {
+        return
+      }
+      this.$emit('close')
     }
   }
 }

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -8,28 +8,31 @@
   height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
   z-index: $z-modal;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .modal-wrapper {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  position: relative;
+  margin: 50px auto;
   background-color: white;
   border-radius: 5px;
   box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
   max-width: calc(100% - 50px); // modals can not be larger than our screen width
 
-  .modal-subwrapper {
-    position: relative;
-    width: 100%;
-    height: 100%;
-  }
-
   .modal-content {
-    padding: 20px;
-    max-height: calc(100vh - 120px);
-    overflow-y: auto;
+    .modal-header {
+      padding: 20px;
+    }
+
+    .modal-body {
+      padding: 20px;
+    }
+
+    .modal-footer {
+      padding: 20px;
+      border-top: 1px solid grey;
+    }
   }
 
   .mdi-close {

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -1,6 +1,6 @@
 @import './_vars';
 
-.modal-backdrop {
+.ovc-modal-backdrop {
   position: fixed;
   left: 0;
   top: 0;
@@ -12,26 +12,30 @@
   overflow-y: auto;
 }
 
-.modal-wrapper {
-  position: relative;
-  margin: 50px auto;
-  background-color: white;
-  border-radius: 5px;
-  box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
-  max-width: calc(100% - 50px); // modals can not be larger than our screen width
+.ovc-modal-wrapper {
+  display: flex;
+  align-items: center;
+  margin: $modal-margin auto;
+  min-height: calc(100% - #{$modal-margin * 2}); // to center our modal
 
-  .modal-content {
-    .modal-header {
+  .ovc-modal-content {
+    position: relative;
+    width: 100%;
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
+
+    .ovc-modal-header {
       padding: 20px;
     }
 
-    .modal-body {
+    .ovc-modal-body {
       padding: 20px;
     }
 
-    .modal-footer {
+    .ovc-modal-footer {
       padding: 20px;
-      border-top: 1px solid grey;
+      background-color: #f0f4f8;
     }
   }
 

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -1,15 +1,14 @@
 @import './_vars';
 
 .ovc-modal-backdrop {
-  position: fixed;
+  position: absolute;
+  display: flex;
   left: 0;
   top: 0;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
   z-index: $z-modal;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .ovc-modal-wrapper {
@@ -26,7 +25,13 @@
     box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
 
     .ovc-modal-header {
+      position: sticky;
+      top: 0;
+      width: auto;
+      border-top-left-radius: 5px;
+      border-top-right-radius: 5px;
       padding: 20px;
+      background-color: #f0f4f8;
     }
 
     .ovc-modal-body {
@@ -34,6 +39,11 @@
     }
 
     .ovc-modal-footer {
+      position: sticky;
+      bottom: 0;
+      width: auto;
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius: 5px;
       padding: 20px;
       background-color: #f0f4f8;
     }
@@ -76,9 +86,8 @@
 
 // the following should be in your global style sheet
 
-body.prevent-scroll {
+.page-container.prevent-scroll {
   position: fixed;
   overflow-y: hidden;
   width: 100%;
-  height: 100%;
 }

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -23,7 +23,7 @@
     width: 100%;
     background-color: white;
     border-radius: 5px;
-    box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: $shadow-xl;
     pointer-events: all;
 
     .ovc-modal-header {
@@ -33,7 +33,7 @@
       border-top-left-radius: 5px;
       border-top-right-radius: 5px;
       padding: 20px;
-      background-color: #f0f4f8;
+      background-color: $grey-10;
     }
 
     .ovc-modal-body {
@@ -47,7 +47,7 @@
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       padding: 20px;
-      background-color: #f0f4f8;
+      background-color: $grey-10;
     }
   }
 

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -23,7 +23,7 @@
     width: 100%;
     background-color: white;
     border-radius: 5px;
-    box-shadow: $shadow-xl;
+    box-shadow: $shadow-2xl;
     pointer-events: all;
 
     .ovc-modal-header {

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -16,6 +16,7 @@
   align-items: center;
   margin: $modal-margin auto;
   min-height: calc(100% - #{$modal-margin * 2}); // to center our modal
+  pointer-events: none;
 
   .ovc-modal-content {
     position: relative;
@@ -23,6 +24,7 @@
     background-color: white;
     border-radius: 5px;
     box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.1);
+    pointer-events: all;
 
     .ovc-modal-header {
       position: sticky;

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -74,6 +74,7 @@
 
 body.prevent-scroll {
   position: fixed;
+  overflow-y: hidden;
   width: 100%;
   height: 100%;
 }

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -84,8 +84,6 @@
   }
 }
 
-// the following should be in your global style sheet
-
 .page-container.prevent-scroll {
   position: fixed;
   overflow-y: hidden;

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -31,3 +31,5 @@ $z-message: 11;
 $z-modal: 19;
 $z-pikaday-select: 9998;
 $z-pikaday: 9999;
+
+$modal-margin: 50px;

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -20,6 +20,24 @@ $red-200: #F44336;
 $green-200: #4FCD3E;
 $yellow-200: #FFEB3B;
 
+$grey-10: #f0f4f8;
+$grey-20: #d9e2ed;
+$grey-30: #bdccdc;
+$grey-40: #9fb3c8;
+$grey-50: #829ab1;
+$grey-60: #627d98;
+$grey-70: #486581;
+$grey-80: #334e68;
+$grey-90: #243a53;
+$grey-100: #102b43;
+
+// shadows (from styleguide)
+$shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+$shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+$shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+$shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+$shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+
 $tr-time: 200ms;
 $tr-ease: ease-out;
 

--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -1,6 +1,5 @@
-const element = document.getElementsByClassName('page-container')[0]
-
 export function freezeBackground () {
+  const element = document.getElementsByClassName('page-container')[0]
   if (element.classList.contains('prevent-scroll')) {
     return // prevent duplicate calls
   }
@@ -10,6 +9,7 @@ export function freezeBackground () {
 }
 
 export function unfreezeBackground () {
+  const element = document.getElementsByClassName('page-container')[0]
   if (!element.classList.contains('prevent-scroll')) {
     return // prevent duplicate calls
   }

--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -1,17 +1,20 @@
+const element = document.getElementsByClassName('page-container')[0]
+
 export function freezeBackground () {
-  if (document.body.classList.contains('prevent-scroll')) {
+  if (element.classList.contains('prevent-scroll')) {
     return // prevent duplicate calls
   }
-  document.body.style.setProperty('top', - (document.documentElement.scrollTop) + 'px' )
-  document.body.classList.add('prevent-scroll')
+  element.style.setProperty('top', - (document.documentElement.scrollTop) + 'px' )
+  document.documentElement.scrollTop = parseInt(top) * -1
+  element.classList.add('prevent-scroll')
 }
 
 export function unfreezeBackground () {
-  if (!document.body.classList.contains('prevent-scroll')) {
+  if (!element.classList.contains('prevent-scroll')) {
     return // prevent duplicate calls
   }
-  const top = document.body.style.getPropertyValue('top')
-  document.body.classList.remove('prevent-scroll')
-  document.body.style.removeProperty('top')
+  const top = element.style.getPropertyValue('top')
+  element.classList.remove('prevent-scroll')
+  element.style.removeProperty('top')
   document.documentElement.scrollTop = parseInt(top) * -1
 }


### PR DESCRIPTION
Upgrade the Modal to
* be scrollable externally instead of internally (like TL)
* accept a header / footer slot..

Content in both header & footer slot will be fixed in position and remain visible when we have a very long modal with scroll-y

All the current content will go into the default slot, which gives us full control over how to customize the design and functionality

Prefixed the modal classes with ovc acronym (officient-vue-components) to avoid class collision (can be left out if we introduce the modal on the whole repo - like we do in below core PR)

Related core PR: https://github.com/officient/officient-core/pull/1464

![image](https://user-images.githubusercontent.com/17768456/58002130-cc921e80-7add-11e9-93d9-ab2c7ac90e7d.png)
