### PR TITLE
Remove custom colour DaysOffTooltip

### DIFF
--- a/src/components/daysoff/DaysOffTooltip.vue
+++ b/src/components/daysoff/DaysOffTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-<tooltip class="BudgetTooltip" :color="`#${item.color}`">
+<tooltip class="BudgetTooltip">
   <template v-if="this.item.limitation === 'limit_in_half_days'">
     <table>
       <tbody>


### PR DESCRIPTION
Background Tooltip to default dark

Related Core PR:
https://github.com/officient/officient-core/pull/1701

![image](https://user-images.githubusercontent.com/17768456/60677792-cc2dc700-9e82-11e9-992b-92ee71a95953.png)
