### PR TITLE
OA-10211 - CORE: fix parsing time-off usage in minutes

### DIFF
--- a/lib/utils/filters.js
+++ b/lib/utils/filters.js
@@ -1,13 +1,13 @@
 import { 
     minutesToHoursMinutes,
-    enagementToHoursMinutes,
+    engagementToHoursMinutes,
     daysOffPartOfDay,
     floatable
 } from '../../src/utils/filters'
 
 export { 
     minutesToHoursMinutes,
-    enagementToHoursMinutes,
+    engagementToHoursMinutes,
     daysOffPartOfDay,
     floatable
  }

--- a/src/components/daysoff/CalendarCoworkersContent.vue
+++ b/src/components/daysoff/CalendarCoworkersContent.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div>
     <div v-for="(item, i) in limitedList" :key="i" class="box-day box-day__coworker">
-      <span><b>{{ item.name.split(' ')[0] }}</b>: {{ item.duration_minutes | enagementToHoursMinutes }}</span>
+      <span><b>{{ item.name.split(' ')[0] }}</b>: {{ item.duration_minutes | engagementToHoursMinutes }}</span>
     </div>
 
     <div v-if="moreList.length > 0" class="box-day box-day__more">
@@ -10,7 +10,7 @@
           <div class="calendar-tooltip-title">{{ $t('COWORKERS') }}</div>
           <div class="calendar-tooltip-content">
             <div v-for="item in moreList" class="calendar-tooltip-item">
-              <span class="calendar-tooltip-item-name">{{ item.name.split(' ')[0] }}</span>: {{ item.duration_minutes | enagementToHoursMinutes }}
+              <span class="calendar-tooltip-item-name">{{ item.name.split(' ')[0] }}</span>: {{ item.duration_minutes | engagementToHoursMinutes }}
             </div>
           </div>
         </div>

--- a/src/components/daysoff/CalendarTooltipItem.vue
+++ b/src/components/daysoff/CalendarTooltipItem.vue
@@ -4,7 +4,7 @@
     <span v-else-if="placeholder" class="calendar-tooltip-item-name">{{ $t(placeholder) }}</span>
 
     <div v-if="item.duration_minutes > 0" class="calendar-tooltip-item-details">
-      <span>{{ item.duration_minutes | enagementToHoursMinutes }}</span>
+      <span>{{ item.duration_minutes | engagementToHoursMinutes }}</span>
       <span v-if="item.duration_minutes > 0 && item.duration_minutes < 5 * 60">
         <!-- If half a day. Show which part of day -->
         - {{ item | daysOffPartOfDay }}
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { enagementToHoursMinutes, daysOffPartOfDay } from '../../utils/filters'
+import { engagementToHoursMinutes, daysOffPartOfDay } from '../../utils/filters'
 
 export default {
   name: 'CalendarTooltipitem',
@@ -28,7 +28,7 @@ export default {
       default: ''
     }
   },
-  filters: { enagementToHoursMinutes, daysOffPartOfDay },
+  filters: { engagementToHoursMinutes, daysOffPartOfDay },
   computed: {
     itemStyles () {
       return {

--- a/src/components/daysoff/DaysOffTooltip.vue
+++ b/src/components/daysoff/DaysOffTooltip.vue
@@ -60,13 +60,12 @@
 
 <script>
 import Tooltip from '../Tooltip'
-import { enagementToHoursMinutes, floatable } from '../../utils/filters'
+import { floatable } from '../../utils/filters'
 
 export default {
   name: 'DaysOffTooltip',
   components: { Tooltip },
   props: ['item'],
-  filters: { enagementToHoursMinutes },
   computed: {
     showTooltipForLimitsInMinutes(){
       if(this.item.limitation !== 'leave_accrual'){

--- a/src/components/daysoff/DaysOffTooltip.vue
+++ b/src/components/daysoff/DaysOffTooltip.vue
@@ -41,16 +41,16 @@
       <tbody>
         <tr v-if="item.minutes_approved > 0">
           <th>{{ $t('APPROVED') }}</th>
-          <td>{{item.minutes_approved | enagementToHoursMinutes}}</td>
+          <td>{{item.minutes_approved | engagementToHoursMinutes}}</td>
         </tr>
         <tr v-if="item.minutes_not_approved > 0">
           <th>{{ $t('PENDING') }}</th>
-          <td>{{item.minutes_not_approved | enagementToHoursMinutes}}</td>
+          <td>{{item.minutes_not_approved | engagementToHoursMinutes}}</td>
         </tr>
         <tr v-if="item.limitation !== 'leave_accrual'">
           <th>{{ $t('LIMIT') }}</th>
           <td v-if="item.limitation === 'unlimited'">{{ $t('UNLIMITED') }}</td>
-          <td v-else>{{item.max_yearly_amount_minutes | enagementToHoursMinutes}}</td>
+          <td v-else>{{item.max_yearly_amount_minutes | engagementToHoursMinutes}}</td>
         </tr>
       </tbody>
     </table>

--- a/src/components/daysoff/DaysOffTooltip.vue
+++ b/src/components/daysoff/DaysOffTooltip.vue
@@ -60,12 +60,13 @@
 
 <script>
 import Tooltip from '../Tooltip'
-import { floatable } from '../../utils/filters'
+import { enagementToHoursMinutes, floatable } from '../../utils/filters'
 
 export default {
   name: 'DaysOffTooltip',
   components: { Tooltip },
   props: ['item'],
+  filters: { enagementToHoursMinutes },
   computed: {
     showTooltipForLimitsInMinutes(){
       if(this.item.limitation !== 'leave_accrual'){

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -10,7 +10,7 @@ export function minutesToHoursMinutes (minutes) {
 	}
 }
 
-export function enagementToHoursMinutes (minutes) {
+export function engagementToHoursMinutes (minutes) {
   if (minutes >= 60) {
     const hours = Math.floor(minutes / 60)
     if (minutes % 60 > 0) return `${hours}h${Math.round(minutes % 60)}`
@@ -51,6 +51,6 @@ export function floatable (number, decimals) {
 
 export default (Vue) => {
   Vue.filter('minutesToHoursMinutes', minutesToHoursMinutes)
-  Vue.filter('enagementToHoursMinutes', enagementToHoursMinutes)
+  Vue.filter('engagementToHoursMinutes', engagementToHoursMinutes)
   Vue.filter('floatable', floatable)
 }


### PR DESCRIPTION
JIRA: https://officientapp.atlassian.net/browse/OA-10211

Correctly import filter `enagementToHoursMinutes` so minutes get correctly parsed to hours and minutes.

Version will have to be created and other repos updated to this version

<img width="1014" alt="image" src="https://github.com/officient/vue-components/assets/15047380/d79c3ad0-2df1-4703-b3e6-7092bb07b322">
